### PR TITLE
ADD: pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Problem
+
+<!-- 이 Pull Request (PR) 이 해결하는 문제 혹은 추가하는 기능 (feature) -->
+
+## Checklist
+
+<!-- 기본적으로 PR을 만들 때 체크해야 하는 내용입니다. 보통 팀을 짜서 코드를 만들다 보면 토론을 해서 추가로 넣거나 변경하는 부분입니다. -->
+<!-- 일단은 생각하게 만드는 체크리스트들을 적어 놓아봅니다. -->
+
+* [ ] Did Pull Request title start with a verb (Add / Remove / Update / etc)?
+<!-- 설명: Pull request는 작고 간결해야 리뷰할때 좋습니다. 그렇게 하려면 동사 하나에 해당하는 내용만 있으면 좋습니다. -->
+* [ ] If Pull Request is large, considered breaking down the PR to smaller PRs
+<!-- 만약에 PR이 커질 경우, 리뷰하는 사람들에게 부담이 되고 검수의 깊이도 얕아지며 에러날 확률도 높아집니다. -->
+<!-- 따라서 팀을 위해 PR을 좀 작게 해볼까? 하는 생각과 행동을 했었는지에 대한 체크입니다. -->
+
+## Details
+
+<!-- PR 이 정확히 무엇을 하는지 여기서 더 자세히 적는 공간입니다. -->
+
+## Screenshots or Recording
+
+<!-- 점점 더 구체화하는 프로젝트들은 시범적으로 돌려보기가 난해해질 수 있고, 그때 스크린샷이나 녹화가 도움이 됩니다. -->
+


### PR DESCRIPTION
## Problem

Github PR template doesn't exist - this PR will add it, and it makes PRs less structured.
We need to make the PRs have structure so we can make sure our PRs follow a certain standard.

## Checklist

* [x] Did Pull Request title start with a verb (Add / Remove / Update / etc)?
<!-- 설명: Pull request는 작고 간결해야 리뷰할때 좋습니다. 그렇게 하려면 동사 하나에 해당하는 내용만 있으면 좋습니다. -->
[🚫] If Pull Request is large, considered breaking down the PR to smaller PRs: PR is really small
<!-- 만약에 PR이 커질 경우, 리뷰하는 사람들에게 부담이 되고 검수의 깊이도 얕아지며 에러날 확률도 높아집니다. -->
<!-- 따라서 팀을 위해 PR을 좀 작게 해볼까? 하는 생각과 행동을 했었는지에 대한 체크입니다. -->

## Details

This adds `pull_request_template.md` to `.github` folder.

## Screenshots or Recording

<!-- 점점 더 구체화하는 프로젝트들은 시범적으로 돌려보기가 난해해질 수 있고, 그때 스크린샷이나 녹화가 도움이 됩니다. -->


